### PR TITLE
Fixing sending wrong headers with proxy tunnel

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -47,9 +47,13 @@ function setProxy(options, config, location) {
     var proxyHost = proxy.hostname || proxy.host; // prefer hostname in case proxy is the result of url.parse
 
     if (isHttps.test(options.protocol)) {
-      // Make sure TLS options are passed from user-configured httpsAgent to the proxy agent
+      // Make sure TLS options are passed from user-configured options to the proxy agent
       var agentOptions = config.httpsAgent ? config.httpsAgent.options : {};
-      var proxyAgentOptions = utils.merge(agentOptions, options, proxy);
+      var tlsOptions = {
+        ca: config.ca || options.ca || agentOptions.ca,
+        rejectUnauthorized: config.rejectUnauthorized || options.rejectUnauthorized || agentOptions.rejectUnauthorized
+      };
+      var proxyAgentOptions = utils.merge(tlsOptions, proxy);
 
       // Workaround: ERR_TLS_CERT_ALTNAME_INVALID when connecting to proxy
       // with custom cert that only has 127.0.0.1 as its CN/SAT


### PR DESCRIPTION
An error in the secure HTTP proxy code path caused HTTP CONNECT requests to include headers from the client request, such as `Content-Length` and `Content-Type` (but without the request body). There was also a problem when setting a `proxy` object with a `host` property because the request `options` would have a `hostname` property, misleading the proxy request.

The intent of the faulty code was to provide means of configuring TLS options for the connection to the proxy (mainly `ca` and `rejectUnauthorized`). This PR fixes the faulty code to be stricter about what it picks from the axios config and request options.